### PR TITLE
marks and connmarks bitmasking; custom mark types

### DIFF
--- a/sbin/firehol.in
+++ b/sbin/firehol.in
@@ -5666,9 +5666,13 @@ rule() {
 					shift
 					local marknot="!"
 				fi
-				test ${softwarnings} -eq 1 -a ! "${mark}" = "any" && softwarning "Overwritting param: mark '${mark}' becomes '${1}'"
-				local num="${1}"
-				local mark="$[num << ${MARKS_SHIFT[$markname]}]/${MARKS_MASKS[$markname]}"
+				test ${softwarnings} -eq 1 -a ! "${mark}" = "any" && softwarning "Overwritting param: mark '${mark}' becomes ${markname} '${1}'"
+				local mark=
+				local num=
+				for num in ${1}
+				do
+					local mark="${mark} $[num << ${MARKS_SHIFT[$markname]}]/${MARKS_MASKS[$markname]}"
+				done
 				shift
 				;;
 				
@@ -5680,9 +5684,13 @@ rule() {
 					shift
 					local marknot="!"
 				fi
-				test ${softwarnings} -eq 1 -a ! "${mark}" = "any" && softwarning "Overwritting param: mark '${mark}' becomes '${1}'"
-				local num="${1}"
-				local mark="$[num << ${MARKS_SHIFT[usermark]}]/${MARKS_MASKS[usermark]}"
+				test ${softwarnings} -eq 1 -a ! "${mark}" = "any" && softwarning "Overwritting param: mark '${mark}' becomes usermark '${1}'"
+				local mark=
+				local num=
+				for num in ${1}
+				do
+					local mark="${mark} $[num << ${MARKS_SHIFT[usermark]}]/${MARKS_MASKS[usermark]}"
+				done
 				shift
 				;;
 				
@@ -5694,9 +5702,13 @@ rule() {
 					shift
 					local marknot="!"
 				fi
-				test ${softwarnings} -eq 1 -a ! "${mark}" = "any" && softwarning "Overwritting param: mark '${mark}' becomes '${1}'"
-				local num="${1}"
-				local mark="$[num << ${MARKS_SHIFT[connmark]}]/${MARKS_MASKS[connmark]}"
+				test ${softwarnings} -eq 1 -a ! "${mark}" = "any" && softwarning "Overwritting param: mark '${mark}' becomes connmark '${1}'"
+				local mark=
+				local num=
+				for num in ${1}
+				do
+					local mark="${mark} $[num << ${MARKS_SHIFT[connmark]}]/${MARKS_MASKS[connmark]}"
+				done
 				shift
 				;;
 				

--- a/sbin/firehol.in
+++ b/sbin/firehol.in
@@ -102,11 +102,13 @@ declare -A MARKS_SHIFT=()
 MARKS_TOTAL_BITS=0
 
 marksreset() {
-	declare -A MARKS_BITS=()
-	declare -A MARKS_MASKS=()
-	declare -A MARKS_MAX=()
-	declare -A MARKS_SHIFT=()
+	#echo >&2 "${FUNCNAME} ${*}: Reseting marks..."
+	MARKS_BITS=()
+	MARKS_MASKS=()
+	MARKS_MAX=()
+	MARKS_SHIFT=()
 	MARKS_TOTAL_BITS=0
+	#declare -p MARKS_BITS MARKS_MASKS MARKS_MAX MARKS_SHIFT >&2
 }
 
 # taken from http://stackoverflow.com/questions/109023/how-to-count-the-number-of-set-bits-in-a-32-bit-integer
@@ -134,14 +136,14 @@ ispoweroftwo() {
 }
 
 markdef() {
-	# echo "${FUNCNAME} ${*}"
+	# echo >&2 "${FUNCNAME} ${*}"
+
 	local name="${1}"; shift
 	local max="${1}"; shift
 
-
 	if [ ! -z "${MARKS_MASKS[$name]}" ]
 	then
-		echo >&2 "Mark type '${name}' already exists. Please use 'marksreset' to reset them before re-defining them."
+		echo >&2 "Mark type '${name}' already exists with mask ${MARKS_MASKS[$name]}. Please use 'marksreset' to reset them before re-defining them."
 		exit 1
 	fi
 
@@ -191,6 +193,7 @@ markdef() {
 	MARKS_MASKS[$name]=$(printf "0x%08x" $mask)
 
 	# echo "Mark $name with $[MARKS_MAX[$name] + 1] possible values (from 0 to ${MARKS_MAX[$name]}), uses ${MARKS_BITS[$name]} bits, has mask ${MARKS_MASKS[$name]} and values should be shifted by ${MARKS_SHIFT[$name]} bits"
+	# declare -p MARKS_BITS MARKS_MASKS MARKS_MAX MARKS_SHIFT >&2
 
 	MARKS_TOTAL_BITS=$[ MARKS_TOTAL_BITS + bits ]
 }

--- a/sbin/firehol.in
+++ b/sbin/firehol.in
@@ -1338,15 +1338,15 @@ declare -a FIREHOL_NS_STACK=()
 FIREHOL_NS_CURR=${FIREHOL_DEFAULT_NAMESPACE}
 FIREHOL_NS_PREP=
 
-peek_namespace() {
-	local ns="${FIREHOL_NS_STACK[0]}"
-	if [ "$ns" = "" ]
-	then
-		echo ${FIREHOL_DEFAULT_NAMESPACE}
-	else
-		echo $ns
-	fi
-}
+#peek_namespace() {
+#	local ns="${FIREHOL_NS_STACK[0]}"
+#	if [ "$ns" = "" ]
+#	then
+#		echo ${FIREHOL_DEFAULT_NAMESPACE}
+#	else
+#		echo $ns
+#	fi
+#}
 
 push_namespace() {
 	if [ "$1" != "ipv4" -a "$1" != "ipv6" -a "$1" != "both" ]
@@ -1364,10 +1364,9 @@ push_namespace() {
 	#echo >&2 "${FUNCNAME} ${@} - namespace stack : '${FIREHOL_NS_STACK[*]}' - call stack : '${FUNCNAME[*]}' - line ${FIREHOL_LINEID}"
 	return 0
 }
-
 pop_namespace() {
 	FIREHOL_NS_STACK=(${FIREHOL_NS_STACK[@]:1})
-	FIREHOL_NS_CURR="${FIREHOL_NS_STACK[0]}"
+	FIREHOL_NS_CURR=${FIREHOL_NS_STACK[0]-${FIREHOL_DEFAULT_NAMESPACE}}
 
 	#echo >&2 "${FUNCNAME} : pops '${FIREHOL_NS_CURR}' - namespace stack : '${FIREHOL_NS_STACK[*]}' - call stack : '${FUNCNAME[*]}' - line ${FIREHOL_LINEID}"
 	return 0

--- a/sbin/firehol.in
+++ b/sbin/firehol.in
@@ -365,7 +365,6 @@ FIREHOL_CONFIG="${FIREHOL_CONFIG_DIR}/firehol.conf"
 FIREHOL_LOCK_FILE="${FIREHOL_RUN_DIR}/firehol.lck"
 
 
-
 # ------------------------------------------------------------------------------
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # ------------------------------------------------------------------------------
@@ -750,6 +749,124 @@ FIREHOL_OUTPUT="${FIREHOL_DIR}/firehol-out.sh"
 FIREHOL_SAVED="${FIREHOL_DIR}/firehol-save.sh"
 FIREHOL_SAVED6="${FIREHOL_DIR}/firehol-save6.sh"
 FIREHOL_TMP="${FIREHOL_DIR}/firehol-tmp.sh"
+
+
+# -----------------------------------------------------------------------------
+# MARKS
+
+declare -A MARKS_BITS='([connmark]="6" [usermark]="7" )'
+declare -A MARKS_MASKS='([connmark]="0x0000003f" [usermark]="0x00001fc0" )'
+declare -A MARKS_MAX='([connmark]="63" [usermark]="127" )'
+declare -A MARKS_SHIFT='([connmark]="0" [usermark]="6" )'
+
+# taken from http://stackoverflow.com/questions/109023/how-to-count-the-number-of-set-bits-in-a-32-bit-integer
+# and http://books.google.gr/books?id=iBNKMspIlqEC&pg=PA66&redir_esc=y#v=onepage&q&f=false
+# counts the number of bits set in a number
+numberofbits() {
+	local x="${1}"
+
+	local x=$[ x - ( (x >> 1) & 0x55555555) ]
+	local x=$[ (x & 0x33333333) + ( (x >> 2) & 0x33333333) ]
+	local x=$[ (x + (x >> 4) ) & 0x0F0F0F0F ]
+	local x=$[ x + (x >> 8) ]
+	local x=$[ x + (x >> 16) ];
+	local bits=$[ x & 0x0000003F ]
+	echo $bits
+}
+
+# taken from http://www.skorks.com/2010/10/write-a-function-to-determine-if-a-number-is-a-power-of-2/
+# checks if a number is power of 2
+ispoweroftwo() {
+	local num="${1}"
+
+	test ! $num = 0 -a $[num & (num - 1)] = 0 && return 0
+	return 1
+}
+
+markdef() {
+	# echo "${FUNCNAME} ${*}"
+	local name="${1}"; shift
+	local max="${1}"; shift
+
+	if [ "${max}" = "rest" ]
+	then
+		local max=$[ 1 << (32 - MARKS_TOTAL_BITS) ]
+	fi
+
+	if ! ispoweroftwo $max
+	then
+		echo >&2 "Max value $max of mark '$name' is not a power of 2."
+		exit 1
+	fi
+
+	# it will be from 0 to max - 1
+	max=$[ max - 1 ]
+
+	if [ $max -lt 1 -o $max -gt $[ 0xffffffff ] ]
+	then
+		echo >&2 "Max value $max of mark '$name' is out of bounds."
+		exit 1
+	fi
+
+	# prevent a fork
+	bits=$(numberofbits $max)
+
+	if [ $bits -eq 0 ]
+	then
+		echo >&2 "INTERNAL ERROR: Cannot figure out the bits set of value $max."
+		exit 1
+	fi
+
+	if [ $[ bits + MARKS_TOTAL_BITS ] -gt 32 ]
+	then
+		echo >&2 "Too many masks were requested. Cannot proceed. Please use fewer."
+		exit 1
+	fi
+
+	# find its mask
+	# we have all the bits we need set in $mark
+	# just shift it to the right position.
+	local mask=$[ max << MARKS_TOTAL_BITS ]
+
+	MARKS_SHIFT[$name]=${MARKS_TOTAL_BITS}
+	MARKS_MAX[$name]=$max
+	MARKS_BITS[$name]=$bits
+	MARKS_MASKS[$name]=$(printf "0x%08x" $mask)
+
+	# echo "Mark $name with $[MARKS_MAX[$name] + 1] possible values (from 0 to ${MARKS_MAX[$name]}), uses ${MARKS_BITS[$name]} bits, has mask ${MARKS_MASKS[$name]} and values should be shifted by ${MARKS_SHIFT[$name]} bits"
+
+	MARKS_TOTAL_BITS=$[ MARKS_TOTAL_BITS + bits ]
+}
+
+if [ -f "${FIREHOL_CONFIG_DIR}/marks.conf" ]
+then
+	declare -A MARKS_BITS=()
+	declare -A MARKS_MASKS=()
+	declare -A MARKS_MAX=()
+	declare -A MARKS_SHIFT=()
+	
+	MARKS_TOTAL_BITS=0
+	source "${FIREHOL_CONFIG_DIR}/marks.conf" || exit 1
+
+	if [ -z "${MARKS_MASKS[connmark]}" ]
+	then
+		echo >&2 "File ${FIREHOL_CONFIG_DIR}/marks.conf does not define a 'connmark' definition."
+		exit 1
+	fi
+
+	if [ -z "${MARKS_MASKS[usermark]}" ]
+	then
+		echo >&2 "File ${FIREHOL_CONFIG_DIR}/marks.conf does not define a 'usermark' definition."
+		exit 1
+	fi
+
+	# save the information for the other tools
+	declare -p MARKS_BITS MARKS_MASKS MARKS_MAX MARKS_SHIFT >"${FIREHOL_SPOOL_DIR}/marks.conf"
+
+elif [ -f "${FIREHOL_SPOOL_DIR}/marks.conf" ]
+then
+	source "${FIREHOL_SPOOL_DIR}/marks.conf" || exit 1
+fi
 
 
 # ------------------------------------------------------------------------------
@@ -3385,7 +3502,6 @@ classify() {
 	return 0
 }
 
-connmark_count=0
 connmark() {
 	work_realcmd_helper $FUNCNAME "$@"
 	
@@ -3397,19 +3513,9 @@ connmark() {
 	local where="${1}"; shift
 	test -z "${where}" && where="OUTPUT POSTROUTING"
 	
-	if [ $mark_count -gt 0 -a $connmark_count -eq 0 ]
-	then
-		softwarning "MARK and CONNMARK can interfere with each other. Check https://github.com/ktsaou/firehol/issues/23#issuecomment-37599754"
-	fi
-	
-	connmark_count=$[connmark_count + 1]
-	
 	if [ "${num}" = "save" ]
 	then
-		# save MARK to CONNMARK
-		shift 1
-		rule table mangle chain INPUT       custom '-m conntrack --ctstate NEW' "$@" action CONNMARK save
-		rule table mangle chain POSTROUTING custom '-m conntrack --ctstate NEW' "$@" action CONNMARK save
+		# backward compatibility - nothing to be done here
 		return 0
 	fi
 
@@ -3419,26 +3525,27 @@ connmark() {
 		return 0
 	fi
 
-	set_work_function "Setting up rules for CONNMARK rule No $connmark_count"
+	set_work_function "Setting up rules for CONNMARK"
 	
+	if [ "${num}" -lt 0 -o "${num}" -gt "${MARKS_MAX[connmark]}" ]
+	then
+		error "FireHOL is configured to use $[${MARKS_MAX[connmark]} + 1] connmarks (from 0 to ${MARKS_MAX[connmark]})."
+		return 1
+	fi
+
+	local mark="$[num << ${MARKS_SHIFT[connmark]}]/${MARKS_MASKS[connmark]}"
+
 	local chain=
 	for chain in ${where}
 	do
 		case "${chain}" in
 			interface)
-				create_chain mangle "connmark.inface.${connmark_count}" "PREROUTING" custom '-m conntrack --ctstate NEW' inface "$@" || return 1
-				rule table mangle chain "connmark.inface.${connmark_count}" action CONNMARK to ${num}
-				rule table mangle chain "connmark.inface.${connmark_count}" action CONNMARK restore
-
-				create_chain mangle "connmark.outface.${connmark_count}" "POSTROUTING" custom '-m conntrack --ctstate NEW' outface "$@" || return 1
-				rule table mangle chain "connmark.outface.${connmark_count}" action CONNMARK to ${num}
-				rule table mangle chain "connmark.outface.${connmark_count}" action CONNMARK restore
+				rule table mangle chain PREROUTING  custom '-m conntrack --ctstate NEW' inface  "${@}" action MARK to "${mark}" || return 1
+				rule table mangle chain POSTROUTING custom '-m conntrack --ctstate NEW' outface "${@}" action MARK to "${mark}" || return 1
 				;;
 
 			*)
-				create_chain mangle "connmark.${chain}.${connmark_count}" "${chain}" custom '-m conntrack --ctstate NEW' "$@" || return 1
-				rule table mangle chain "connmark.${chain}.${connmark_count}" action CONNMARK to ${num}
-				rule table mangle chain "connmark.${chain}.${connmark_count}" action CONNMARK restore
+				rule table mangle chain "${chain}" custom '-m conntrack --ctstate NEW' "${@}" action MARK to "${mark}" || return 1
 				;;
 		esac
 	done
@@ -3446,7 +3553,6 @@ connmark() {
 	return 0
 }
 
-mark_count=0
 mark() {
 	work_realcmd_helper $FUNCNAME "$@"
 	
@@ -3458,17 +3564,18 @@ mark() {
 	local where="${1}"; shift
 	test -z "${where}" && where=OUTPUT
 	
-	if [ $mark_count -eq 0 -a $connmark_count -gt 0 ]
-	then
-		softwarning "MARK and CONNMARK can interfere with each other. Check https://github.com/ktsaou/firehol/issues/23#issuecomment-37599754"
-	fi
-
-	mark_count=$[mark_count + 1]
-	
 	set_work_function "Setting up rules for MARK"
 	
-	create_chain mangle "mark.${mark_count}" "${where}" "$@" || return 1
-	iptables_both -t mangle -A "mark.${mark_count}" -j MARK --set-mark ${num}
+	if [ "${num}" -lt 0 -o "${num}" -gt "${MARKS_MAX[usermark]}" ]
+	then
+		error "FireHOL is configured to use $[${MARKS_MAX[usermark]} + 1] usermarks (from 0 to ${MARKS_MAX[usermark]})."
+		return 1
+	fi
+
+	# we assume this is always 'usermark'
+	local mark="$[num << ${MARKS_SHIFT[usermark]}]/${MARKS_MASKS[usermark]}"
+
+	rule table mangle chain "${where}" custom '-m conntrack --ctstate NEW' "${@}" action MARK to "${mark}" || return 1
 	
 	return 0
 }
@@ -4624,13 +4731,13 @@ close_router() {
 close_master() {
 	set_work_function "Finilizing firewall policies"
 	
-	if [ $connmark_count -gt 0 ]
-	then
-		# if connmark has been used, add MARK restoration from CONNMARK, at the top of mangle
-		# copy CONNMARK to MARK
-		iptables_both -t mangle -I OUTPUT     1 -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark
-		iptables_both -t mangle -I PREROUTING 1 -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark
-	fi
+	# copy CONNMARK to MARK at the top of mangle, on entry points
+	iptables_both -t mangle -I OUTPUT     1 -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark
+	iptables_both -t mangle -I PREROUTING 1 -m conntrack --ctstate ESTABLISHED,RELATED -j CONNMARK --restore-mark
+
+	# save MARK to CONNMARK at the end of mangle, on exit points
+	iptables_both -t mangle -A INPUT       -m conntrack --ctstate NEW -j CONNMARK --save-mark
+	iptables_both -t mangle -A POSTROUTING -m conntrack --ctstate NEW -j CONNMARK --save-mark
 
 	# Accept all related traffic to the established connections
 	rule chain INPUT state RELATED action ACCEPT || return 1
@@ -5487,6 +5594,34 @@ rule() {
 				;;
 				
 			mark|MARK)
+				shift
+				local marknot=
+				if [ "${1}" = "not" -o "${1}" = "NOT" ]
+				then
+					shift
+					local marknot="!"
+				fi
+				test ${softwarnings} -eq 1 -a ! "${mark}" = "any" && softwarning "Overwritting param: mark '${mark}' becomes '${1}'"
+				local num="${1}"
+				local mark="$[num << ${MARKS_SHIFT[usermark]}]/${MARKS_MASKS[usermark]}"
+				shift
+				;;
+				
+			connmark|CONNMARK)
+				shift
+				local marknot=
+				if [ "${1}" = "not" -o "${1}" = "NOT" ]
+				then
+					shift
+					local marknot="!"
+				fi
+				test ${softwarnings} -eq 1 -a ! "${mark}" = "any" && softwarning "Overwritting param: mark '${mark}' becomes '${1}'"
+				local num="${1}"
+				local mark="$[num << ${MARKS_SHIFT[connmark]}]/${MARKS_MASKS[connmark]}"
+				shift
+				;;
+				
+			rawmark|RAWMARK)
 				shift
 				local marknot=
 				if [ "${1}" = "not" -o "${1}" = "NOT" ]

--- a/sbin/firehol.in
+++ b/sbin/firehol.in
@@ -1361,16 +1361,15 @@ push_namespace() {
 	fi
 	FIREHOL_NS_STACK=("$1" "${FIREHOL_NS_STACK[@]}")
 	FIREHOL_NS_CURR="$1"
-	#echo >&2 "${FUNCNAME} ${@} == ${FIREHOL_NS_STACK[*]}"
+	#echo >&2 "${FUNCNAME} ${@} - namespace stack : '${FIREHOL_NS_STACK[*]}' - call stack : '${FUNCNAME[*]}' - line ${FIREHOL_LINEID}"
 	return 0
 }
 
 pop_namespace() {
+	FIREHOL_NS_STACK=(${FIREHOL_NS_STACK[@]:1})
 	FIREHOL_NS_CURR="${FIREHOL_NS_STACK[0]}"
-	unset FIREHOL_NS_STACK[0]
-	FIREHOL_NS_STACK=("${FIREHOL_NS_STACK[@]}")
 
-	#echo >&2 "${FUNCNAME} ${FIREHOL_NS_CURR} == ${FIREHOL_NS_STACK[*]}"
+	#echo >&2 "${FUNCNAME} : pops '${FIREHOL_NS_CURR}' - namespace stack : '${FIREHOL_NS_STACK[*]}' - call stack : '${FUNCNAME[*]}' - line ${FIREHOL_LINEID}"
 	return 0
 }
 

--- a/sbin/firehol.in
+++ b/sbin/firehol.in
@@ -84,6 +84,111 @@ FIREHOL_DEFAULT_WORKING_DIRECTORY="${PWD}"
 # Make sure we don't get localized results
 export LC_ALL=C
 
+
+# ------------------------------------------------------------------------------
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# ------------------------------------------------------------------------------
+#
+# BITMASKED MARKS
+#
+# ------------------------------------------------------------------------------
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# ------------------------------------------------------------------------------
+
+declare -A MARKS_BITS=()
+declare -A MARKS_MASKS=()
+declare -A MARKS_MAX=()
+declare -A MARKS_SHIFT=()
+MARKS_TOTAL_BITS=0
+
+marksreset() {
+	declare -A MARKS_BITS=()
+	declare -A MARKS_MASKS=()
+	declare -A MARKS_MAX=()
+	declare -A MARKS_SHIFT=()
+	MARKS_TOTAL_BITS=0
+}
+
+# taken from http://stackoverflow.com/questions/109023/how-to-count-the-number-of-set-bits-in-a-32-bit-integer
+# and http://books.google.gr/books?id=iBNKMspIlqEC&pg=PA66&redir_esc=y#v=onepage&q&f=false
+# counts the number of bits set in a number
+numberofbits() {
+	local x="${1}"
+
+	local x=$[ x - ( (x >> 1) & 0x55555555) ]
+	local x=$[ (x & 0x33333333) + ( (x >> 2) & 0x33333333) ]
+	local x=$[ (x + (x >> 4) ) & 0x0F0F0F0F ]
+	local x=$[ x + (x >> 8) ]
+	local x=$[ x + (x >> 16) ];
+	local bits=$[ x & 0x0000003F ]
+	echo $bits
+}
+
+# taken from http://www.skorks.com/2010/10/write-a-function-to-determine-if-a-number-is-a-power-of-2/
+# checks if a number is power of 2
+ispoweroftwo() {
+	local num="${1}"
+
+	test ! $num = 0 -a $[num & (num - 1)] = 0 && return 0
+	return 1
+}
+
+markdef() {
+	# echo "${FUNCNAME} ${*}"
+	local name="${1}"; shift
+	local max="${1}"; shift
+
+	if [ "${max}" = "rest" ]
+	then
+		local max=$[ 1 << (32 - MARKS_TOTAL_BITS) ]
+	fi
+
+	if ! ispoweroftwo $max
+	then
+		echo >&2 "Max value $max of mark '$name' is not a power of 2."
+		exit 1
+	fi
+
+	# it will be from 0 to max - 1
+	max=$[ max - 1 ]
+
+	if [ $max -lt 1 -o $max -gt $[ 0xffffffff ] ]
+	then
+		echo >&2 "Max value $max of mark '$name' is out of bounds."
+		exit 1
+	fi
+
+	# prevent a fork
+	bits=$(numberofbits $max)
+
+	if [ $bits -eq 0 ]
+	then
+		echo >&2 "INTERNAL ERROR: Cannot figure out the bits set of value $max."
+		exit 1
+	fi
+
+	if [ $[ bits + MARKS_TOTAL_BITS ] -gt 32 ]
+	then
+		echo >&2 "Too many masks were requested. Cannot proceed. Please use fewer."
+		exit 1
+	fi
+
+	# find its mask
+	# we have all the bits we need set in $mark
+	# just shift it to the right position.
+	local mask=$[ max << MARKS_TOTAL_BITS ]
+
+	MARKS_SHIFT[$name]=${MARKS_TOTAL_BITS}
+	MARKS_MAX[$name]=$max
+	MARKS_BITS[$name]=$bits
+	MARKS_MASKS[$name]=$(printf "0x%08x" $mask)
+
+	# echo "Mark $name with $[MARKS_MAX[$name] + 1] possible values (from 0 to ${MARKS_MAX[$name]}), uses ${MARKS_BITS[$name]} bits, has mask ${MARKS_MASKS[$name]} and values should be shifted by ${MARKS_SHIFT[$name]} bits"
+
+	MARKS_TOTAL_BITS=$[ MARKS_TOTAL_BITS + bits ]
+}
+
+
 # ------------------------------------------------------------------------------
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # ------------------------------------------------------------------------------
@@ -283,6 +388,29 @@ FIREHOL_TRUST_LOOPBACK=1
 
 
 # ----------------------------------------------------------------------
+# IPTABLES MARKS BITMASKING
+
+# FireHOL allows multiple independent MARKs.
+# By default FireHOL requires 'connmark' and 'usermark'.
+# The possible values supported by each may be defined here.
+# The value must be a power of two.
+
+# reset the internal marks to empty - do not remove
+marksreset
+
+# connmarks are used by the connmark helper
+markdef connmark 64
+
+# usermark are used by the mark helper
+markdef usermark 128
+
+# Additional types may be defined like this:
+# markdef qosmark 8
+# To use it use 'custommark' helper and match
+# The first argument to both is the mark name (qosmark in this case)
+
+
+# ----------------------------------------------------------------------
 # IPTABLES PACKETS LOGGING
 
 # LOG mode for iptables
@@ -363,6 +491,21 @@ FIREHOL_CONFIG="${FIREHOL_CONFIG_DIR}/firehol.conf"
 
 # Concurrent run control
 FIREHOL_LOCK_FILE="${FIREHOL_RUN_DIR}/firehol.lck"
+
+if [ -z "${MARKS_MASKS[connmark]}" ]
+then
+	echo >&2 "File ${FIREHOL_CONFIG_DIR}/marks.conf does not define a 'connmark' definition."
+	exit 1
+fi
+
+if [ -z "${MARKS_MASKS[usermark]}" ]
+then
+	echo >&2 "File ${FIREHOL_CONFIG_DIR}/marks.conf does not define a 'usermark' definition."
+	exit 1
+fi
+
+# save the information for the other tools
+declare -p MARKS_BITS MARKS_MASKS MARKS_MAX MARKS_SHIFT >"${FIREHOL_SPOOL_DIR}/marks.conf"
 
 
 # ------------------------------------------------------------------------------
@@ -749,124 +892,6 @@ FIREHOL_OUTPUT="${FIREHOL_DIR}/firehol-out.sh"
 FIREHOL_SAVED="${FIREHOL_DIR}/firehol-save.sh"
 FIREHOL_SAVED6="${FIREHOL_DIR}/firehol-save6.sh"
 FIREHOL_TMP="${FIREHOL_DIR}/firehol-tmp.sh"
-
-
-# -----------------------------------------------------------------------------
-# MARKS
-
-declare -A MARKS_BITS='([connmark]="6" [usermark]="7" )'
-declare -A MARKS_MASKS='([connmark]="0x0000003f" [usermark]="0x00001fc0" )'
-declare -A MARKS_MAX='([connmark]="63" [usermark]="127" )'
-declare -A MARKS_SHIFT='([connmark]="0" [usermark]="6" )'
-
-# taken from http://stackoverflow.com/questions/109023/how-to-count-the-number-of-set-bits-in-a-32-bit-integer
-# and http://books.google.gr/books?id=iBNKMspIlqEC&pg=PA66&redir_esc=y#v=onepage&q&f=false
-# counts the number of bits set in a number
-numberofbits() {
-	local x="${1}"
-
-	local x=$[ x - ( (x >> 1) & 0x55555555) ]
-	local x=$[ (x & 0x33333333) + ( (x >> 2) & 0x33333333) ]
-	local x=$[ (x + (x >> 4) ) & 0x0F0F0F0F ]
-	local x=$[ x + (x >> 8) ]
-	local x=$[ x + (x >> 16) ];
-	local bits=$[ x & 0x0000003F ]
-	echo $bits
-}
-
-# taken from http://www.skorks.com/2010/10/write-a-function-to-determine-if-a-number-is-a-power-of-2/
-# checks if a number is power of 2
-ispoweroftwo() {
-	local num="${1}"
-
-	test ! $num = 0 -a $[num & (num - 1)] = 0 && return 0
-	return 1
-}
-
-markdef() {
-	# echo "${FUNCNAME} ${*}"
-	local name="${1}"; shift
-	local max="${1}"; shift
-
-	if [ "${max}" = "rest" ]
-	then
-		local max=$[ 1 << (32 - MARKS_TOTAL_BITS) ]
-	fi
-
-	if ! ispoweroftwo $max
-	then
-		echo >&2 "Max value $max of mark '$name' is not a power of 2."
-		exit 1
-	fi
-
-	# it will be from 0 to max - 1
-	max=$[ max - 1 ]
-
-	if [ $max -lt 1 -o $max -gt $[ 0xffffffff ] ]
-	then
-		echo >&2 "Max value $max of mark '$name' is out of bounds."
-		exit 1
-	fi
-
-	# prevent a fork
-	bits=$(numberofbits $max)
-
-	if [ $bits -eq 0 ]
-	then
-		echo >&2 "INTERNAL ERROR: Cannot figure out the bits set of value $max."
-		exit 1
-	fi
-
-	if [ $[ bits + MARKS_TOTAL_BITS ] -gt 32 ]
-	then
-		echo >&2 "Too many masks were requested. Cannot proceed. Please use fewer."
-		exit 1
-	fi
-
-	# find its mask
-	# we have all the bits we need set in $mark
-	# just shift it to the right position.
-	local mask=$[ max << MARKS_TOTAL_BITS ]
-
-	MARKS_SHIFT[$name]=${MARKS_TOTAL_BITS}
-	MARKS_MAX[$name]=$max
-	MARKS_BITS[$name]=$bits
-	MARKS_MASKS[$name]=$(printf "0x%08x" $mask)
-
-	# echo "Mark $name with $[MARKS_MAX[$name] + 1] possible values (from 0 to ${MARKS_MAX[$name]}), uses ${MARKS_BITS[$name]} bits, has mask ${MARKS_MASKS[$name]} and values should be shifted by ${MARKS_SHIFT[$name]} bits"
-
-	MARKS_TOTAL_BITS=$[ MARKS_TOTAL_BITS + bits ]
-}
-
-if [ -f "${FIREHOL_CONFIG_DIR}/marks.conf" ]
-then
-	declare -A MARKS_BITS=()
-	declare -A MARKS_MASKS=()
-	declare -A MARKS_MAX=()
-	declare -A MARKS_SHIFT=()
-	
-	MARKS_TOTAL_BITS=0
-	source "${FIREHOL_CONFIG_DIR}/marks.conf" || exit 1
-
-	if [ -z "${MARKS_MASKS[connmark]}" ]
-	then
-		echo >&2 "File ${FIREHOL_CONFIG_DIR}/marks.conf does not define a 'connmark' definition."
-		exit 1
-	fi
-
-	if [ -z "${MARKS_MASKS[usermark]}" ]
-	then
-		echo >&2 "File ${FIREHOL_CONFIG_DIR}/marks.conf does not define a 'usermark' definition."
-		exit 1
-	fi
-
-	# save the information for the other tools
-	declare -p MARKS_BITS MARKS_MASKS MARKS_MAX MARKS_SHIFT >"${FIREHOL_SPOOL_DIR}/marks.conf"
-
-elif [ -f "${FIREHOL_SPOOL_DIR}/marks.conf" ]
-then
-	source "${FIREHOL_SPOOL_DIR}/marks.conf" || exit 1
-fi
 
 
 # ------------------------------------------------------------------------------
@@ -3198,7 +3223,7 @@ FIREHOL_TPROXY_ROUTE_DEVICE="lo"
 
 tproxy_setup_ip_route() {
 	require_cmd ip
-	
+
 	local x=
 	for x in inet inet6
 	do
@@ -3560,31 +3585,35 @@ connmark() {
 	return 0
 }
 
-mark() {
+custommark() {
 	work_realcmd_helper $FUNCNAME "$@"
 	
 	set_work_function -ne "Initializing $FUNCNAME"
 	
 	require_work clear || ( error "$FUNCNAME cannot be used in '${work_cmd}'. Put it before any '${work_cmd}' definition."; return 1 )
 	
+	local name="${1}"; shift
 	local num="${1}"; shift
 	local where="${1}"; shift
 	test -z "${where}" && where=OUTPUT
 	
 	set_work_function "Setting up rules for MARK"
 	
-	if [ "${num}" -lt 0 -o "${num}" -gt "${MARKS_MAX[usermark]}" ]
+	if [ "${num}" -lt 0 -o "${num}" -gt "${MARKS_MAX[$name]}" ]
 	then
-		error "FireHOL is configured to use $[${MARKS_MAX[usermark]} + 1] usermarks (from 0 to ${MARKS_MAX[usermark]})."
+		error "FireHOL is configured to use $[${MARKS_MAX[$name]} + 1] $name (from 0 to ${MARKS_MAX[$name]})."
 		return 1
 	fi
 
-	# we assume this is always 'usermark'
-	local mark="$[num << ${MARKS_SHIFT[usermark]}]/${MARKS_MASKS[usermark]}"
+	local mark="$[num << ${MARKS_SHIFT[$name]}]/${MARKS_MASKS[$name]}"
 
 	rule table mangle chain "${where}" custom '-m conntrack --ctstate NEW' "${@}" action MARK to "${mark}" || return 1
 	
 	return 0
+}
+
+mark() {
+	custommark usermark "${@}"
 }
 
 tos_count=0
@@ -5597,6 +5626,22 @@ rule() {
 				fi
 				test ${softwarnings} -eq 1 -a ! "${proto}" = "any" && softwarning "Overwritting param: proto '${proto}' becomes '${1}'"
 				local proto="${1}"
+				shift
+				;;
+				
+			custommark|CUSTOMMARK)
+				shift
+				local markname="${1}"
+				shift
+				local marknot=
+				if [ "${1}" = "not" -o "${1}" = "NOT" ]
+				then
+					shift
+					local marknot="!"
+				fi
+				test ${softwarnings} -eq 1 -a ! "${mark}" = "any" && softwarning "Overwritting param: mark '${mark}' becomes '${1}'"
+				local num="${1}"
+				local mark="$[num << ${MARKS_SHIFT[$markname]}]/${MARKS_MASKS[$markname]}"
 				shift
 				;;
 				

--- a/sbin/firehol.in
+++ b/sbin/firehol.in
@@ -138,6 +138,13 @@ markdef() {
 	local name="${1}"; shift
 	local max="${1}"; shift
 
+
+	if [ ! -z "${MARKS_MASKS[$name]}" ]
+	then
+		echo >&2 "Mark type '${name}' already exists. Please use 'marksreset' to reset them before re-defining them."
+		exit 1
+	fi
+
 	if [ "${max}" = "rest" ]
 	then
 		local max=$[ 1 << (32 - MARKS_TOTAL_BITS) ]

--- a/sbin/firehol.in
+++ b/sbin/firehol.in
@@ -1298,7 +1298,8 @@ FIREHOL_LINEID="INIT"
 # Suggested by Fco.Felix Belmonte <ffelix@gescosoft.com>
 # Note that each of the complex services
 # may add to this variable the kernel modules it requires.
-FIREHOL_KERNEL_MODULES=
+declare -A FIREHOL_KERNEL_MODULES=()
+
 #
 # In the configuration file you can write:
 #
@@ -1333,15 +1334,15 @@ FIREHOL_CONF_SHOW=1
 
 # ------------------------------------------------------------------------------
 # Keep information about the current namespace: ipv4, ipv6 or both
-FIREHOL_NS_STACK=
-FIREHOL_NS_CURR=$FIREHOL_DEFAULT_NAMESPACE
+declare -a FIREHOL_NS_STACK=()
+FIREHOL_NS_CURR=${FIREHOL_DEFAULT_NAMESPACE}
 FIREHOL_NS_PREP=
 
 peek_namespace() {
-	local ns=$(echo $FIREHOL_NS_STACK | cut -f1 -d:)
+	local ns="${FIREHOL_NS_STACK[0]}"
 	if [ "$ns" = "" ]
 	then
-		echo $FIREHOL_DEFAULT_NAMESPACE
+		echo ${FIREHOL_DEFAULT_NAMESPACE}
 	else
 		echo $ns
 	fi
@@ -1358,14 +1359,18 @@ push_namespace() {
 		error "Cannot use namespace $1 within ${FIREHOL_NS_CURR}"
 		return 1
 	fi
-	FIREHOL_NS_STACK="$1:$FIREHOL_NS_STACK"
-	FIREHOL_NS_CURR=$(peek_namespace)
+	FIREHOL_NS_STACK=("$1" "${FIREHOL_NS_STACK[@]}")
+	FIREHOL_NS_CURR="$1"
+	#echo >&2 "${FUNCNAME} ${@} == ${FIREHOL_NS_STACK[*]}"
 	return 0
 }
 
 pop_namespace() {
-	FIREHOL_NS_STACK=$(echo $FIREHOL_NS_STACK | cut -f2- -d:)
-	FIREHOL_NS_CURR=$(peek_namespace)
+	FIREHOL_NS_CURR="${FIREHOL_NS_STACK[0]}"
+	unset FIREHOL_NS_STACK[0]
+	FIREHOL_NS_STACK=("${FIREHOL_NS_STACK[@]}")
+
+	#echo >&2 "${FUNCNAME} ${FIREHOL_NS_CURR} == ${FIREHOL_NS_STACK[*]}"
 	return 0
 }
 
@@ -1450,42 +1455,42 @@ both() {
 	return $status
 }
 
-expression_list() {
-	# Clean up a complex expression expressions, such that e.g.
-	# fun0 ( x ) word  word2 fun1(a b) ...
-	# Becomes:
-	#  fun0(x)
-	#  word
-	#  word2
-	#  fun(a,b)
-	#  ....
-	# 1st sed: remove excess space, insert newlines at end of functions
-	# 2nd sed: insert newlines before functions that are preceded by words
-	# 3nd sed: function? no: split words to lines. yes: comma parameters.
-	echo "$@" | tr '\t' ' ' | \
-		sed -e 's/   */ /g' \
-			-e 's/ *\([()]\) */\1/g' \
-			-e 's/)/)\
-/g' | \
-		sed -e 's/ \([^ ][^ ]*\)(/\
-\1(/' | \
-		sed -e '/[()]/bfun' -e 's/ /\n/g' -e ':fun' -e 's/ /,/g'
-}
-
-eval_param() {
-	expression_list "$@" | \
-	while read exp
-	do
-		case "$exp" in
-			*"("*)
-				$(echo "$exp" | tr '(),' '   ')
-			;;
-			*)
-				echo "$exp"
-			;;
-		esac
-	done
-}
+#expression_list() {
+#	# Clean up a complex expression expressions, such that e.g.
+#	# fun0 ( x ) word  word2 fun1(a b) ...
+#	# Becomes:
+#	#  fun0(x)
+#	#  word
+#	#  word2
+#	#  fun(a,b)
+#	#  ....
+#	# 1st sed: remove excess space, insert newlines at end of functions
+#	# 2nd sed: insert newlines before functions that are preceded by words
+#	# 3nd sed: function? no: split words to lines. yes: comma parameters.
+#	echo "$@" | tr '\t' ' ' | \
+#		sed -e 's/   */ /g' \
+#			-e 's/ *\([()]\) */\1/g' \
+#			-e 's/)/)\
+#/g' | \
+#		sed -e 's/ \([^ ][^ ]*\)(/\
+#\1(/' | \
+#		sed -e '/[()]/bfun' -e 's/ /\n/g' -e ':fun' -e 's/ /,/g'
+#}
+#
+#eval_param() {
+#	expression_list "$@" | \
+#	while read exp
+#	do
+#		case "$exp" in
+#			*"("*)
+#				$(echo "$exp" | tr '(),' '   ')
+#			;;
+#			*)
+#				echo "$exp"
+#			;;
+#		esac
+#	done
+#}
 
 # ------------------------------------------------------------------------------
 # Keep information about the current primary command
@@ -2995,14 +3000,25 @@ rules_custom() {
 	# ----------------------------------------------------------------------
 	
 	local sp=
+	local oIFS="${IFS}"
+	local -a args=()
 	for sp in ${my_server_ports}
 	do
 		local proto=
 		local sport=
 		
-		IFS="/" read proto sport <<EOF
-$sp
-EOF
+		# this code is 21% faster than the next
+		args=()
+		IFS="/" args=( $sp )
+		IFS="${oIFS}"
+		local proto=${args[0]}
+		local sport=${args[1]}
+
+		# the code above is 21% faster than this
+#		IFS="/" read proto sport <<EOF
+#$sp
+#EOF
+		# echo >&2 "Parsing '${sp}' to proto='${proto}' and sport='${sport}'"
 		
 		local cp=
 		for cp in ${my_client_ports}
@@ -3806,7 +3822,7 @@ version() {
 		ENABLE_IPV6=0
 		FIREHOL_DEFAULT_NAMESPACE=ipv4
 		FIREHOL_NS_CURR=$FIREHOL_DEFAULT_NAMESPACE
-		FIREHOL_NS_STACK=
+		FIREHOL_NS_STACK=()
 		FIREHOL_NS_PREP=
 		warning "Running version 5 config. Update configuration to version 6 for IPv6 support. See http://firehol.org/upgrade/#config-version-${FIREHOL_VERSION}"
 	fi
@@ -3827,10 +3843,10 @@ interface() {
 	# --- reset namespace
 	if [ "${FIREHOL_NS_PREP}" != "" ]
 	then
-		FIREHOL_NS_STACK=${FIREHOL_NS_PREP}
+		FIREHOL_NS_STACK=(${FIREHOL_NS_PREP})
 		FIREHOL_NS_CURR=${FIREHOL_NS_PREP}
 	else
-		FIREHOL_NS_STACK=${FIREHOL_DEFAULT_NAMESPACE}
+		FIREHOL_NS_STACK=(${FIREHOL_DEFAULT_NAMESPACE})
 		FIREHOL_NS_CURR=${FIREHOL_DEFAULT_NAMESPACE}
 	fi
 	FIREHOL_NS_PREP=
@@ -3889,10 +3905,10 @@ router() {
 	# --- reset namespace
 	if [ "${FIREHOL_NS_PREP}" != "" ]
 	then
-		FIREHOL_NS_STACK=${FIREHOL_NS_PREP}
+		FIREHOL_NS_STACK=(${FIREHOL_NS_PREP})
 		FIREHOL_NS_CURR=${FIREHOL_NS_PREP}
 	else
-		FIREHOL_NS_STACK=${FIREHOL_DEFAULT_NAMESPACE}
+		FIREHOL_NS_STACK=(${FIREHOL_DEFAULT_NAMESPACE})
 		FIREHOL_NS_CURR=${FIREHOL_DEFAULT_NAMESPACE}
 	fi
 	FIREHOL_NS_PREP=
@@ -4026,35 +4042,31 @@ run_fast() {
 		n=table
 	fi
 	
-	if [ "z$1" = "z-t" ]
+	if [ "z${1}" = "z-t" ]
 	then
-		local t="$2"
+		local t="${2}"
 		shift 2
 	fi
 	
 	case "$1" in
-		-P)	echo ":$2 $3 [0:0]" >>$FIREHOL_DIR/fast/${n}.${t}.policy
+		-P)	echo ":$2 $3 [0:0]" >>"${FIREHOL_DIR}/fast/${n}.${t}.policy"
 			;;
 		
-		-N)	echo ":$2 - [0:0]" >>$FIREHOL_DIR/fast/${n}.${t}.chains
+		-N)	echo ":$2 - [0:0]" >>"${FIREHOL_DIR}/fast/${n}.${t}.chains"
 			;;
 		
-		-A)	${CAT_CMD} <<EOFA >>$FIREHOL_DIR/fast/${n}.${t}.rules
-${@}
-EOFA
+		-A|-I)	echo "${*}" >>"${FIREHOL_DIR}/fast/${n}.${t}.rules"
+#${CAT_CMD} <<EOF >>"${FIREHOL_DIR}/fast/${n}.${t}.rules"
+#${@}
+#EOF
 			;;
 			
-		-I)	${CAT_CMD} <<EOFI >>$FIREHOL_DIR/fast/${n}.${t}.rules
-${@}
-EOFI
-			;;
-		
 		# if it is none of the above, we execute it normally.
-		*)	echo "Ignoring command '${cmd} -t ${t} ${@}'"
+		*)	echo >&2 "Ignoring command '${cmd} -t ${t} ${@}'"
 			;;
 	esac
 	
-	test ! -f $FIREHOL_DIR/fast/${n}s/${t} && ${TOUCH_CMD} $FIREHOL_DIR/fast/${n}s/${t}
+	test ! -f "${FIREHOL_DIR}/fast/${n}s/${t}" && ${TOUCH_CMD} "${FIREHOL_DIR}/fast/${n}s/${t}"
 	return 0
 }
 
@@ -4560,15 +4572,12 @@ load_kernel_module() {
 # kernel modules to load, during activation-phase.
 require_kernel_module() {
 	local new="${1}"
-	
-	local m=
-	for m in ${FIREHOL_KERNEL_MODULES}
-	do
-		test "${m}" = "${new}" && return 0
-	done
-	
-	set_work_function "Adding kernel module '${new}' in the list of kernel modules to load"
-	FIREHOL_KERNEL_MODULES="${FIREHOL_KERNEL_MODULES} ${new}"
+
+	if [ -z "${FIREHOL_KERNEL_MODULES[$new]}" ]
+	then
+		set_work_function "Adding kernel module '${new}' in the list of kernel modules to load"
+		FIREHOL_KERNEL_MODULES[$new]="1"
+	fi
 	
 	return 0
 }
@@ -5423,11 +5432,13 @@ rule() {
 					fi
 					if running_ipv4; then
 						test ${softwarnings} -eq 1 -a ! "${src4}" = "default" && softwarning "Overwritting param: src4 '${src4}' becomes '${1}'"
-						local src4=$(ipv4 eval_param "${1}")
+						#local src4=$(ipv4 eval_param "${1}")
+						local src4="${1}"
 					fi
 					if running_ipv6; then
 						test ${softwarnings} -eq 1 -a ! "${src6}" = "default" && softwarning "Overwritting param: src6 '${src6}' becomes '${1}'"
-						local src6=$(ipv6 eval_param "${1}")
+						# local src6=$(ipv6 eval_param "${1}")
+						local src6="${1}"
 					fi
 				else
 					if running_ipv4; then
@@ -5448,11 +5459,13 @@ rule() {
 					fi
 					if running_ipv4; then
 						test ${softwarnings} -eq 1 -a ! "${dst4}" = "default" && softwarning "Overwritting param: dst4 '${dst4}' becomes '${1}'"
-						local dst4=$(ipv4 eval_param "${1}")
+						#local dst4=$(ipv4 eval_param "${1}")
+						local dst4="${1}"
 					fi
 					if running_ipv6; then
 						test ${softwarnings} -eq 1 -a ! "${dst6}" = "default" && softwarning "Overwritting param: dst6 '${dst6}' becomes '${1}'"
-						local dst6=$(ipv6 eval_param "${1}")
+						#local dst6=$(ipv6 eval_param "${1}")
+						local dst6="${1}"
 					fi
 				fi
 				pop_namespace
@@ -5490,11 +5503,13 @@ rule() {
 					fi
 					if running_ipv4; then
 						test ${softwarnings} -eq 1 -a ! "${dst4}" = "default" && softwarning "Overwritting param: dst4 '${dst4}' becomes '${1}'"
-						local dst4=$(ipv4 eval_param "${1}")
+						# local dst4=$(ipv4 eval_param "${1}")
+						local dst4="${1}"
 					fi
 					if running_ipv6; then
 						test ${softwarnings} -eq 1 -a ! "${dst6}" = "default" && softwarning "Overwritting param: dst6 '${dst6}' becomes '${1}'"
-						local dst6=$(ipv6 eval_param "${1}")
+						#local dst6=$(ipv6 eval_param "${1}")
+						local dst6="${1}"
 					fi
 				else
 					if running_ipv4; then
@@ -5515,11 +5530,13 @@ rule() {
 					fi
 					if running_ipv4; then
 						test ${softwarnings} -eq 1 -a ! "${src4}" = "default" && softwarning "Overwritting param: src6 '${src4}' becomes '${1}'"
-						local src4=$(ipv4 eval_param "${1}")
+						#local src4=$(ipv4 eval_param "${1}")
+						local src4="${1}"
 					fi
 					if running_ipv6; then
 						test ${softwarnings} -eq 1 -a ! "${src6}" = "default" && softwarning "Overwritting param: src6 '${src6}' becomes '${1}'"
-						local src6=$(ipv6 eval_param "${1}")
+						#local src6=$(ipv6 eval_param "${1}")
+						local src6="${1}"
 					fi
 				fi
 				pop_namespace
@@ -6293,6 +6310,36 @@ rule() {
 	test "${src6}" = "default" && local src6="any"
 	test "${dst6}" = "default" && local dst6="any"
 
+	if [ ! "${src4}" = "any" ]
+	then
+		src4=${src4//reserved_ips()/${RESERVED_IPV4}}
+		src4=${src4//private_ips()/${PRIVATE_IPV4}}
+		src4=${src4//multicast_ips()/${MULTICAST_IPV4}}
+		src4=${src4//unroutable_ips()/${UNROUTABLE_IPV4}}
+	fi
+	if [ ! "${dst4}" = "any" ]
+	then
+		dst4=${dst4//reserved_ips()/${RESERVED_IPV4}}
+		dst4=${dst4//private_ips()/${PRIVATE_IPV4}}
+		dst4=${dst4//multicast_ips()/${MULTICAST_IPV4}}
+		dst4=${dst4//unroutable_ips()/${UNROUTABLE_IPV4}}
+	fi
+
+	if [ ! "${src6}" = "any" ]
+	then
+		src6=${src6//reserved_ips()/${RESERVED_IPV6}}
+		src6=${src6//private_ips()/${PRIVATE_IPV6}}
+		src6=${src6//multicast_ips()/${MULTICAST_IPV6}}
+		src6=${src6//unroutable_ips()/${UNROUTABLE_IPV6}}
+	fi
+	if [ ! "${dst6}" = "any" ]
+	then
+		dst6=${dst6//reserved_ips()/${RESERVED_IPV6}}
+		dst6=${dst6//private_ips()/${PRIVATE_IPV6}}
+		dst6=${dst6//multicast_ips()/${MULTICAST_IPV6}}
+		dst6=${dst6//unroutable_ips()/${UNROUTABLE_IPV6}}
+	fi
+
 	# ----------------------------------------------------------------------------------
 	# Do we have negative contitions?
 	# If yes, we have to:
@@ -6685,6 +6732,11 @@ rule() {
 			;;
 	esac
 	
+	# keep a list of all ip versions we need
+	local ipvall=
+	running_ipv4 && local ipvall="ipv4"
+	running_ipv6 && local ipvall="${ipvall} ipv6"
+
 	# uid
 	local tuid=
 	for tuid in ${uid}
@@ -6925,111 +6977,75 @@ rule() {
 				local -a mc_arg=("-m" "mac" "--mac-source" "${mc}")
 				;;
 		esac
-	
-	if running_ipv4; then
-		# src4
-		local s=
-		for s in ${src4}
-		do
-			local -a s_arg=()
-			case ${s} in
-				any|ANY)
-					;;
 
-				*)
-					local -a s_arg=("-s" "${s}")
-					;;
-			esac
+	# ipvall	
+	local ipv=
+	for ipv in ${ipvall}
+	do
+		case "${ipv}" in
+			ipv4)
+				local iptables="iptables"
+				local src="${src4}"
+				local dst="${dst4}"
+				;;
 
-		# dst4
-		local d=
-		for d in ${dst4}
-		do
-			local -a d_arg=()
-			case ${d} in
-				any|ANY)
-					;;
+			ipv6)
+				local iptables="ip6tables"
+				local src="${src6}"
+				local dst="${dst6}"
+				;;
+		esac
 
-				*)
-					local -a d_arg=("-d" "${d}")
-					;;
-			esac
+	# src
+	local s=
+	for s in ${src}
+	do
+		local -a s_arg=()
+		case ${s} in
+			any|ANY)
+				;;
 
-		# build the command
-		declare -a basecmd=("${inf_arg[@]}" "${outf_arg[@]}" "${physdev_arg[@]}" "${inph_arg[@]}" "${outph_arg[@]}" "${limit_arg[@]}" "${iplimit_arg[@]}" "${proto_arg[@]}" "${s_arg[@]}" "${sp_arg[@]}" "${d_arg[@]}" "${dp_arg[@]}" "${owner_arg[@]}" "${uid_arg[@]}" "${gid_arg[@]}" "${pid_arg[@]}" "${sid_arg[@]}" "${cmd_arg[@]}" "${addrtype_arg[@]}" "${stp_arg[@]}" "${dtp_arg[@]}" "${state_arg[@]}" "${mc_arg[@]}" "${mark_arg[@]}" "${tos_arg[@]}" "${dscp_arg[@]}")
+			*)
+				local -a s_arg=("-s" "${s}")
+				;;
+		esac
 
-		if [ "$logrule" = "limit" ]
-		then
-			iptables ${table} -A "${chain}" "${basecmd[@]}" ${custom} -m limit --limit "${FIREHOL_LOG_FREQUENCY}" --limit-burst "${FIREHOL_LOG_BURST}" -j ${FIREHOL_LOG_MODE} ${FIREHOL_LOG_OPTIONS} "${logopts_arg[@]}"
-		elif [ "$logrule" = "normal" ]
-		then
-			iptables ${table} -A "${chain}" "${basecmd[@]}" ${custom} -j ${FIREHOL_LOG_MODE} ${FIREHOL_LOG_OPTIONS} "${logopts_arg[@]}"
-		fi
+	# dst
+	local d=
+	for d in ${dst}
+	do
+		local -a d_arg=()
+		case ${d} in
+			any|ANY)
+				;;
 
-		if [ ! -z "${accounting}" ]
-		then
-			iptables ${table} -A "${chain}" "${basecmd[@]}" ${custom} -m nfacct --nfacct-name "${accounting}"
-		fi
+			*)
+				local -a d_arg=("-d" "${d}")
+				;;
+		esac
 
-		# do it!
-		rule_action_param iptables "${action}" "${pr}" "${statenot}" "${state}" "${table}" "${action_param[@]}" -- ${table} -A "${chain}" "${basecmd[@]}" ${custom} || local failed=$[failed + 1]
+	# build the command
+	declare -a basecmd=("${inf_arg[@]}" "${outf_arg[@]}" "${physdev_arg[@]}" "${inph_arg[@]}" "${outph_arg[@]}" "${limit_arg[@]}" "${iplimit_arg[@]}" "${proto_arg[@]}" "${s_arg[@]}" "${sp_arg[@]}" "${d_arg[@]}" "${dp_arg[@]}" "${owner_arg[@]}" "${uid_arg[@]}" "${gid_arg[@]}" "${pid_arg[@]}" "${sid_arg[@]}" "${cmd_arg[@]}" "${addrtype_arg[@]}" "${stp_arg[@]}" "${dtp_arg[@]}" "${state_arg[@]}" "${mc_arg[@]}" "${mark_arg[@]}" "${tos_arg[@]}" "${dscp_arg[@]}")
 
-		done # dst4
-		done # src4
+	if [ "$logrule" = "limit" ]
+	then
+		${iptables} ${table} -A "${chain}" "${basecmd[@]}" ${custom} -m limit --limit "${FIREHOL_LOG_FREQUENCY}" --limit-burst "${FIREHOL_LOG_BURST}" -j ${FIREHOL_LOG_MODE} ${FIREHOL_LOG_OPTIONS} "${logopts_arg[@]}"
+	elif [ "$logrule" = "normal" ]
+	then
+		${iptables} ${table} -A "${chain}" "${basecmd[@]}" ${custom} -j ${FIREHOL_LOG_MODE} ${FIREHOL_LOG_OPTIONS} "${logopts_arg[@]}"
 	fi
 
-	if running_ipv6; then
-		# src6
-		local s=
-		for s in ${src6}
-		do
-			local -a s_arg=()
-			case ${s} in
-				any|ANY)
-					;;
-
-				*)
-					local -a s_arg=("-s" "${s}")
-					;;
-			esac
-
-		# dst6
-		local d=
-		for d in ${dst6}
-		do
-			local -a d_arg=()
-			case ${d} in
-				any|ANY)
-					;;
-
-				*)
-					local -a d_arg=("-d" "${d}")
-					;;
-			esac
-
-		# build the command
-		declare -a basecmd=("${inf_arg[@]}" "${outf_arg[@]}" "${physdev_arg[@]}" "${inph_arg[@]}" "${outph_arg[@]}" "${limit_arg[@]}" "${iplimit_arg[@]}" "${proto_arg[@]}" "${s_arg[@]}" "${sp_arg[@]}" "${d_arg[@]}" "${dp_arg[@]}" "${owner_arg[@]}" "${uid_arg[@]}" "${gid_arg[@]}" "${pid_arg[@]}" "${sid_arg[@]}" "${cmd_arg[@]}" "${addrtype_arg[@]}" "${stp_arg[@]}" "${dtp_arg[@]}" "${state_arg[@]}" "${mc_arg[@]}" "${mark_arg[@]}" "${tos_arg[@]}" "${dscp_arg[@]}")
-
-		if [ "$logrule" = "limit" ]
-		then
-			ip6tables ${table} -A "${chain}" "${basecmd[@]}" ${custom} -m limit --limit "${FIREHOL_LOG_FREQUENCY}" --limit-burst "${FIREHOL_LOG_BURST}" -j ${FIREHOL_LOG_MODE} ${FIREHOL_LOG_OPTIONS} "${logopts_arg[@]}"
-		elif [ "$logrule" = "normal" ]
-		then
-			ip6tables ${table} -A "${chain}" "${basecmd[@]}" ${custom}  -j ${FIREHOL_LOG_MODE} ${FIREHOL_LOG_OPTIONS} "${logopts_arg[@]}"
-		fi
-
-		if [ ! -z "${accounting}" ]
-		then
-			iptables ${table} -A "${chain}" "${basecmd[@]}" ${custom} -m nfacct --nfacct-name "${accounting}"
-		fi
-
-		# do it!
-		rule_action_param ip6tables "${action}" "${pr}" "${statenot}" "${state}" "${table}" "${action_param[@]}" -- ${table} -A "${chain}" "${basecmd[@]}" ${custom} || local failed=$[failed + 1]
-
-		done # dst6
-		done # src6
+	if [ ! -z "${accounting}" ]
+	then
+		${iptables} ${table} -A "${chain}" "${basecmd[@]}" ${custom} -m nfacct --nfacct-name "${accounting}"
 	fi
 
+	# do it!
+	rule_action_param ${iptables} "${action}" "${pr}" "${statenot}" "${state}" "${table}" "${action_param[@]}" -- ${table} -A "${chain}" "${basecmd[@]}" ${custom} || local failed=$[failed + 1]
+
+	done # dst
+	done # src
+	done # ipvall
 	done # mac
 	done # dport
 	done # sport
@@ -8970,7 +8986,7 @@ initialize_firewall() {
 		load_kernel_module ip6_tables
 	fi
 	
-	for m in ${FIREHOL_KERNEL_MODULES}
+	for m in ${!FIREHOL_KERNEL_MODULES[*]}
 	do
 		postprocess -ne -ns load_kernel_module $m
 	done

--- a/sbin/firehol.in
+++ b/sbin/firehol.in
@@ -3192,16 +3192,18 @@ transparent_squid() {
 	transparent_proxy 80 "$@"
 }
 
-FIREHOL_TPROXY_MARK="0xffff/0xffff"
-FIREHOL_TPROXY_IP_ROUTE_TABLE="999"
+FIREHOL_TPROXY_MARK=
+FIREHOL_TPROXY_IP_ROUTE_TABLE="241"
 FIREHOL_TPROXY_ROUTE_DEVICE="lo"
 
 tproxy_setup_ip_route() {
+	require_cmd ip
+	
 	local x=
 	for x in inet inet6
 	do
 		# remove the existing ip rules for this mark
-		postprocess -ne ${IP_CMD} -f $x rule del from all fwmark $FIREHOL_TPROXY_MARK
+		postprocess -ne ${IP_CMD} -f $x rule del lookup $FIREHOL_TPROXY_IP_ROUTE_TABLE
 
 		# remove the existing rules from the ip route table
 		postprocess -ne ${IP_CMD} -f $x route flush table $FIREHOL_TPROXY_IP_ROUTE_TABLE
@@ -3229,6 +3231,11 @@ tproxy() {
 	
 	local ports="${1}"; shift
 	
+	if [ -z "${FIREHOL_TPROXY_MARK}" ]
+	then
+		FIREHOL_TPROXY_MARK="$[ MARKS_MAX[usermark] << MARKS_SHIFT[usermark] ]/${MARKS_MASKS[usermark]}"
+	fi
+
 	local tproxy_action_options="tproxy-mark $FIREHOL_TPROXY_MARK"
 	local tport=
 	local tip=

--- a/sbin/fireqos.in
+++ b/sbin/fireqos.in
@@ -2060,21 +2060,33 @@ match() {
 				;;
 				
 			connmark|connmarks)
-				test ! "${mark}" = "any" && warning "Overwritting mark '${mark}' with '${2}'"
+				test ! "${mark}" = "any" && warning "Overwritting mark '${marktype}/${mark}' with 'connmark/${2}'"
 				local marktype="connmark"
 				local mark="$2"
 				shift
 				;;
 				
 			mark|marks)
-				test ! "${mark}" = "any" && warning "Overwritting mark '${mark}' with '${2}'"
+				test ! "${mark}" = "any" && warning "Overwritting mark '${marktype}/${mark}' with 'usermark/${2}'"
 				local marktype="usermark"
 				local mark="$2"
 				shift
 				;;
 				
+			custommark|custommarks)
+				test ! "${mark}" = "any" && warning "Overwritting mark '${marktype}/${mark}' with '${2}/${3}'"
+				local marktype="$2"
+				local mark="$3"
+				shift 2
+				if [ -z "${MARKS_BITS[$marktype]}" ]
+				then
+					error "Mark type '${marktype}' is not defined."
+					return 1
+				fi
+				;;
+				
 			rawmark|rawmarks)
-				test ! "${mark}" = "any" && warning "Overwritting mark '${mark}' with '${2}'"
+				test ! "${mark}" = "any" && warning "Overwritting mark '${marktype}/${mark}' with '${2}'"
 				local marktype=
 				local mark="$2"
 				shift

--- a/sbin/fireqos.in
+++ b/sbin/fireqos.in
@@ -273,6 +273,22 @@ server_tcp_ports="tcp/any"
 server_udp_ports="udp/any"
 server_surfing_ports="tcp/0:1023"
 
+# -----------------------------------------------------------------------------
+# Default FireHOL marks
+
+declare -A MARKS_BITS='([connmark]="6" [usermark]="7" )'
+declare -A MARKS_MASKS='([connmark]="0x0000003f" [usermark]="0x00001fc0" )'
+declare -A MARKS_MAX='([connmark]="63" [usermark]="127" )'
+declare -A MARKS_SHIFT='([connmark]="0" [usermark]="6" )'
+
+FIREHOL_SPOOL_DIR="/var/spool/firehol"
+if [ -f "${FIREHOL_SPOOL_DIR}/marks.conf" ]
+then
+	source "${FIREHOL_SPOOL_DIR}/marks.conf" || exit 1
+fi
+
+# -----------------------------------------------------------------------------
+
 save() {
 	[ ! $interface_save -eq 1 ] && return 0
 
@@ -1967,6 +1983,7 @@ match() {
 	local ip=any
 	local tos=any
 	local mark=any
+	local marktype=
 	local srcmac=any
 	local dstmac=any
 	local class=$class_name
@@ -2042,7 +2059,23 @@ match() {
 				shift
 				;;
 				
+			connmark|connmarks)
+				test ! "${mark}" = "any" && warning "Overwritting mark '${mark}' with '${2}'"
+				local marktype="connmark"
+				local mark="$2"
+				shift
+				;;
+				
 			mark|marks)
+				test ! "${mark}" = "any" && warning "Overwritting mark '${mark}' with '${2}'"
+				local marktype="usermark"
+				local mark="$2"
+				shift
+				;;
+				
+			rawmark|rawmarks)
+				test ! "${mark}" = "any" && warning "Overwritting mark '${mark}' with '${2}'"
+				local marktype=
 				local mark="$2"
 				shift
 				;;
@@ -2460,22 +2493,22 @@ match() {
 										case "$ttos" in
 											any)	;;
 											
-											min-delay|minimize-delay|minimum-delay|low-delay|interactive)
+											lowdelay|min-delay|minimize-delay|minimum-delay|low-delay|interactive)
 												local tos_value="0x10"
 												local tos_mask="0x10"
 												;;
 												
-											maximize-throughput|maximum-throughput|max-throughput|high-throughput|bulk)
+											throughput|maximize-throughput|maximum-throughput|max-throughput|high-throughput|bulk)
 												local tos_value="0x08"
 												local tos_mask="0x08"
 												;;
 												
-											maximize-reliability|maximum-reliability|max-reliability|reliable)
+											reliability|maximize-reliability|maximum-reliability|max-reliability|reliable)
 												local tos_value="0x04"
 												local tos_mask="0x04"
 												;;
 												
-											min-cost|minimize-cost|minimum-cost|low-cost|cheap)
+											mincost|min-cost|minimize-cost|minimum-cost|low-cost|cheap)
 												local tos_value="0x02"
 												local tos_mask="0x02"
 												;;
@@ -2515,11 +2548,17 @@ match() {
 										local tmark=
 										for tmark in $mark
 										do
+											# http://mailman.ds9a.nl/pipermail/lartc/2007q3/021364.html
 											local mark_arg=
 											case "$tmark" in
 												any)	;;
-												
-												*)	local mark_arg="handle $tmark fw"
+												*)	if [ -z "${marktype}" ]
+													then
+														# local mark_arg="handle $tmark fw"
+														local mark_arg="u32 match mark `echo "$tmark" | tr "/" " "`"
+													else
+														local mark_arg="u32 match mark $[tmark << ${MARKS_SHIFT[$marktype]}] ${MARKS_MASKS[$marktype]}"
+													fi
 													;;
 											esac
 											
@@ -2557,7 +2596,7 @@ match() {
 														[ -z "$proto_arg$ip_arg$src_arg$dst_arg$port_arg$sport_arg$dport_arg$tos_arg$ack_arg$syn_arg" ] && local u32=
 													fi
 													
-													[ ! -z "$u32" -a ! -z "$mark_arg" ] && local mark_arg="and $mark_arg"
+													# [ ! -z "$u32" -a ! -z "$mark_arg" ] && local mark_arg="and $mark_arg"
 													
 													local estimator=
 													if [ ! -z "$estimator_interval" -a ! -z "$estimator_decay" ]

--- a/sbin/link-balancer.in
+++ b/sbin/link-balancer.in
@@ -1283,7 +1283,7 @@ rules() {
 							local x=
 							for x in $1
 							do
-								mark+=("$[x << ${MARKS_SHIFT[$marktype]}]/${MARKS_MASKS[$marktype]}")
+								mark+=(`printf "0x%x/${MARKS_MASKS[$marktype]}" "$[x << ${MARKS_SHIFT[$marktype]}]"`)
 							done
 						fi
 						;;

--- a/sbin/link-balancer.in
+++ b/sbin/link-balancer.in
@@ -1220,6 +1220,16 @@ rules() {
 				local cmd="mark"
 				;;
 
+			custommark)
+				local marktype="${2}"; shift
+				local cmd="mark"
+				if [ -z "${MARKS_BITS[$marktype]}" ]
+				then
+					error "Mark type '${marktype}' is not defined."
+					exit 1
+				fi
+				;;
+
 			connmark)
 				local marktype="connmark"
 				local cmd="mark"

--- a/sbin/link-balancer.in
+++ b/sbin/link-balancer.in
@@ -161,6 +161,23 @@ LB_DEFAULT_IPV=4
 cd "${LB_RUN_DIR}" || exit 1
 LB_DIR="`mktemp -d "${LB_RUN_DIR}/temp-XXXXXXXXXX"`" || exit 1
 
+
+# -----------------------------------------------------------------------------
+# Default FireHOL marks
+
+declare -A MARKS_BITS='([connmark]="6" [usermark]="7" )'
+declare -A MARKS_MASKS='([connmark]="0x0000003f" [usermark]="0x00001fc0" )'
+declare -A MARKS_MAX='([connmark]="63" [usermark]="127" )'
+declare -A MARKS_SHIFT='([connmark]="0" [usermark]="6" )'
+
+FIREHOL_SPOOL_DIR="/var/spool/firehol"
+if [ -f "${FIREHOL_SPOOL_DIR}/marks.conf" ]
+then
+	source "${FIREHOL_SPOOL_DIR}/marks.conf" || exit 1
+fi
+
+# -----------------------------------------------------------------------------
+
 LB_RESULT_CODE=1
 lb_exit() {
 	cd /tmp
@@ -1160,6 +1177,8 @@ rules() {
 	local -a dst=()
 	local -a inface=()
 
+	local marktype=
+
 	local action=
 	local table=
 	local not=
@@ -1191,7 +1210,18 @@ rules() {
 				local action="${1}"
 				;;
 
-			mark|connmark)
+			rawmark)
+				local marktype=
+				local cmd="mark"
+				;;
+
+			mark)
+				local marktype="usermark"
+				local cmd="mark"
+				;;
+
+			connmark)
+				local marktype="connmark"
 				local cmd="mark"
 				;;
 
@@ -1237,18 +1267,27 @@ rules() {
 
 			loadfile)
 				case "${cmd}" in
-					mark) mark+=(`loadfile "${2}"`);;
-					tos) tos+=(`loadfile "${2}"`);;
 					src) src+=(`loadfile "${2}"`);;
 					dst) dst+=(`loadfile "${2}"`);;
-					inface) inface+=(`loadfile "${2}"`);;
 				esac
 				shift
 				;;
 
 			*)
 				case "${cmd}" in
-					mark) mark+=("$1");;
+					mark)
+						if [ -z "${marktype}" ]
+						then
+							mark+=("$1")
+						else
+							local x=
+							for x in $1
+							do
+								mark+=("$[x << ${MARKS_SHIFT[$marktype]}]/${MARKS_MASKS[$marktype]}")
+							done
+						fi
+						;;
+
 					tos) tos+=("$1");;
 					src) src+=("$1");;
 					dst) dst+=("$1");;
@@ -1391,7 +1430,8 @@ normalize_rules() {
 		-e "s| tos 2 | tos mincost |g" \
 		-e "s| tos 4 | tos reliability |g" \
 		-e "s| tos 8 | tos throughput |g" \
-		-e "s| tos 10 | tos lowdelay |g"
+		-e "s| tos 10 | tos lowdelay |g" \
+		-e "s|0x0\+|0x|g"
 }
 
 finalize_rules() {


### PR DESCRIPTION
The whole FireHOL suite supports internally 2 types of marks: usermarks and connmarks.

Connmarks are used by link-balancer to mark the interfaces traffic came in order to send the replies back via the same path. All tools support (by default) 64 connmarks.

Usermarks are used by all tools to mark traffic the user wants. The mark firehol helper, the mark firehol match, the mark fireqos match and the mark link-balancer policy based routing match, they all refer to usermarks. All tools support (by default) 128 usermarks.

Marks and connmarks are now bitmasked and co-exist. FireHOL always saves and restores marks for each connection. New marks are assigned on NEW connections and saved to connection state when the packet leaves the machine. Marks are restored on ESTABLISHED and RELATED connections when a packet is received.

The user may match an arbitrary mark, bypassing the new bitmasking mechanism, by requesting a rawmark match. Rawmark matching works on all tools. Rawmark syntax is exactly the same with mark, for each tool.

The user may re-define how mark bitmasking works by editing /etc/firehol/firehol-defaults.conf. The default bitmasking is:

```sh
markdef connmark 64
markdef usermark 128
```

The user may change the numbers to specify more of less marks for each kind. The value must be a power of two.

The user may also define additional mark types by adding `markdef` lines. These custom marks can then be used by using the `custommark` match, on all tools (firehol must be activated before the other tools get the changes). `custommark` works exactly like `mark`, but its first parameter must be the name given to the markdef line. Additionally, FireHOL defines the `custommark` helper to assign custom marks to traffic.

Related to issue #23 