### PR TITLE
Set missing variable for IPv6

### DIFF
--- a/sbin/firehol.in
+++ b/sbin/firehol.in
@@ -6982,6 +6982,7 @@ case "${arg}" in
 	explain)
 		test ! -z "${1}" && softwarning "Arguments after parameter '${arg}' are ignored."
 		firewall_policy_applied=1
+		firewall_policy6_applied=1
 		FIREHOL_MODE="EXPLAIN"
 		;;
 	


### PR DESCRIPTION
Without setting `$firewall_policy6_applied` firehol would print the
following error message during explain:

> /usr/sbin/firehol: line 3667: [: -eq: unary operator expected

The default definition of `$firewall_policy6_applied` is not executed
in explain mode (like the definition in `$firewall_policy_applied`) and
`$firewall_policy6_applied` is undefined in line 3667.